### PR TITLE
fix writing randomStreamId

### DIFF
--- a/KeePassKit/IO/KDBX/KPKKdbxArchiver.m
+++ b/KeePassKit/IO/KDBX/KPKKdbxArchiver.m
@@ -251,7 +251,8 @@
     [self.dataWriter writeData:headerHmac];
     
     /* inner header */
-    [self _writeHeaderField:(uint32_t)KPKInnerHeaderKeyRandomStreamId bytes:(void *)self.randomStreamID length:sizeof(self.randomStreamID)];
+    uint32_t randomStreamId = CFSwapInt32HostToLittle(_randomStreamID);
+    [self _writeHeaderField:(uint32_t)KPKInnerHeaderKeyRandomStreamId bytes:&randomStreamId length:sizeof(randomStreamId)];
     [self _writeHeaderField:(uint32_t)KPKInnerHeaderKeyRandomStreamKey data:self.randomStreamKey];
     for(KPKBinary *binary in self.binaries) {
       uint8_t buffer[binary.data.length + 1];


### PR DESCRIPTION
This crashes the test. However even with this fix, there are still some test cases are failing. Is this expected?