### PR TITLE
unify uint type usage

### DIFF
--- a/KeePassKit/IO/KPKDataStreamWriter.h
+++ b/KeePassKit/IO/KPKDataStreamWriter.h
@@ -34,10 +34,10 @@
 - (void)writeStringAsNullTerminatedCString:(NSString *)string encoding:(NSStringEncoding)encoding;
 - (void)writeStringData:(NSString *)string encoding:(NSStringEncoding)encoding;
 - (void)writeBytes:(const void *)buffer length:(NSUInteger)lenght;
-- (void)writeByte:(uint8)byte;
-- (void)write2Bytes:(uint16)bytes;
-- (void)write4Bytes:(uint32)bytes;
-- (void)write8Bytes:(uint64)bytes;
+- (void)writeByte:(uint8_t)byte;
+- (void)write2Bytes:(uint16_t)bytes;
+- (void)write4Bytes:(uint32_t)bytes;
+- (void)write8Bytes:(uint64_t)bytes;
 - (void)writeInteger:(NSUInteger)integer;
 
 @property (nonatomic, readonly, copy) NSData *data;

--- a/KeePassKit/IO/KPKDataStreamWriter.m
+++ b/KeePassKit/IO/KPKDataStreamWriter.m
@@ -75,17 +75,17 @@
 - (void)writeBytes:(const void *)buffer length:(NSUInteger)lenght {
   [self _writeBytes:buffer length:lenght];
 }
-- (void)writeByte:(uint8)byte {
+- (void)writeByte:(uint8_t)byte {
   [self _writeBytes:&byte length:1];
 }
-- (void)write2Bytes:(uint16)bytes {
+- (void)write2Bytes:(uint16_t)bytes {
   [self _writeBytes:&bytes length:2];
 }
-- (void)write4Bytes:(uint32)bytes {
+- (void)write4Bytes:(uint32_t)bytes {
   [self _writeBytes:&bytes length:4];
 }
 
-- (void)write8Bytes:(uint64)bytes {
+- (void)write8Bytes:(uint64_t)bytes {
   [self _writeBytes:&bytes length:8];
 }
 


### PR DESCRIPTION
Somehow on iOS there is no `uint8` and only `uint8_t`. I figure it would be nice to unify the usage of uint types.