### PR TITLE
Added podspec

### DIFF
--- a/KeePassKit.podspec
+++ b/KeePassKit.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/MacPass/KeePassKit"
   s.license      = "GPLv3"
   s.author       = { "Michael Starke" => "michael.starke@hicknhack-software.com" }
-  s.source        = { :git => "https://github.com/MacPass/KeePassKit.git", :tag => s.version.to_s, :submodules => true}
+  s.source        = { :git => "https://github.com/MacPass/KeePassKit.git", :tag => s.version.to_s, :submodules => true }
   s.requires_arc  = true
 
   s.ios.deployment_target = "8.0"
@@ -28,16 +28,16 @@ Pod::Spec.new do |s|
     ss.source_files = 'KissXML/KissXML/**/*.{h,m}'
     ss.private_header_files = 'KissXML/KissXML/Private/**/*.h'
     ss.library      = 'xml2'
-    ss.xcconfig     = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2'}
+    ss.xcconfig     = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2' }
   end
 
   s.subspec 'Argon2' do |ss|
     ss.source_files = "Argon2/src/*.c", "Argon2/include/*.h", "Argon2/src/blake2/*.{h,c}"
-    ss.exclude_files = "Argon2/src/test.c", "Argon2/src/run.c", "Argon2/src/bench.c", "Argon2/src/blake2/blamka-round-ref.h"
-    ss.osx.exclude_files = "Argon2/src/ref.c"
-    ss.ios.exclude_files = "Argon2/src/opt.c"
-    ss.watchos.exclude_files = "Argon2/src/opt.c"
-    ss.tvos.exclude_files = "Argon2/src/opt.c"
+    ss.exclude_files = "Argon2/src/test.c", "Argon2/src/run.c", "Argon2/src/bench.c"
+    ss.osx.exclude_files = "Argon2/src/ref.c", "Argon2/src/blake2/blamka-round-ref.h"
+    ss.ios.exclude_files = "Argon2/src/opt.c", "Argon2/src/blake2/blamka-round-opt.h"
+    ss.watchos.exclude_files = "Argon2/src/opt.c", "Argon2/src/blake2/blamka-round-ref.h"
+    ss.tvos.exclude_files = "Argon2/src/opt.c", "Argon2/src/blake2/blamka-round-ref.h"
   end
 
   s.subspec 'ChaCha20' do |ss|

--- a/KeePassKit.podspec
+++ b/KeePassKit.podspec
@@ -1,0 +1,50 @@
+Pod::Spec.new do |s|
+  s.name         = "KeePassKit"
+  s.version      = "1.0.5"
+  s.summary      = "KeePass Database loading, storing and manipulation framework."
+  s.homepage     = "https://github.com/MacPass/KeePassKit"
+  s.license      = "GPLv3"
+  s.author       = { "Michael Starke" => "michael.starke@hicknhack-software.com" }
+  s.source        = { :git => "https://github.com/MacPass/KeePassKit.git", :tag => s.version.to_s, :submodules => true}
+  s.requires_arc  = true
+
+  s.ios.deployment_target = "8.0"
+  s.osx.deployment_target = "10.9"
+  s.watchos.deployment_target = "2.0"
+  s.tvos.deployment_target = "9.0"
+
+  s.subspec 'Core' do |ss|
+    ss.source_files  = "KeePassKit/**/*.{h,m}"
+    ss.private_header_files = "KeePassKit/KeePassKit_Private.h"
+    ss.dependency 'KeePassKit/KissXML'
+    ss.dependency 'KeePassKit/Argon2'
+    ss.dependency 'KeePassKit/ChaCha20'
+    ss.dependency 'KeePassKit/TwoFish'
+
+    ss.libraries = 'z'
+  end
+
+  s.subspec 'KissXML' do |ss|
+    ss.source_files = 'KissXML/KissXML/**/*.{h,m}'
+    ss.private_header_files = 'KissXML/KissXML/Private/**/*.h'
+    ss.library      = 'xml2'
+    ss.xcconfig     = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2'}
+  end
+
+  s.subspec 'Argon2' do |ss|
+    ss.source_files = "Argon2/src/*.c", "Argon2/include/*.h", "Argon2/src/blake2/*.{h,c}"
+    ss.exclude_files = "Argon2/src/test.c", "Argon2/src/run.c", "Argon2/src/bench.c", "Argon2/src/blake2/blamka-round-ref.h"
+    ss.osx.exclude_files = "Argon2/src/ref.c"
+    ss.ios.exclude_files = "Argon2/src/opt.c"
+    ss.watchos.exclude_files = "Argon2/src/opt.c"
+    ss.tvos.exclude_files = "Argon2/src/opt.c"
+  end
+
+  s.subspec 'ChaCha20' do |ss|
+    ss.source_files = "ChaCha20/chacha20_simple.{h,c}"
+  end
+
+  s.subspec 'TwoFish' do |ss|
+    ss.source_files = "TwoFish/twofish.{h,c}"
+  end
+end

--- a/KeePassKit/KeePassKit.h
+++ b/KeePassKit/KeePassKit.h
@@ -6,7 +6,12 @@
 //  Copyright © 2015 HicknHack Software GmbH. All rights reserved.
 //
 
-@import Foundation;
+#import <Foundation/Foundation.h>
+
+#ifndef _KEEPASSKIT_
+#define _KEEPASSKIT_
+
+#if __has_include(<KeePassKit/KeePassKit.h>)
 
 //! Project version number for KeePassKit.
 FOUNDATION_EXPORT double KeePassKitVersionNumber;
@@ -14,7 +19,57 @@ FOUNDATION_EXPORT double KeePassKitVersionNumber;
 //! Project version string for KeePassKit.
 FOUNDATION_EXPORT const unsigned char KeePassKitVersionString[];
 
-#import "KPKPlatformIncludes.h"
+#import <KeePassKit/KPKTypes.h>
+#import <KeePassKit/KPKUTIs.h>
+#import <KeePassKit/KPKIconTypes.h>
+
+#import <KeePassKit/KPKData.h>
+#import <KeePassKit/KPKNumber.h>
+
+#import <KeePassKit/KPKFormat.h>
+#import <KeePassKit/KPKKdbxFormat.h>
+#import <KeePassKit/KPKKeyDerivation.h>
+#import <KeePassKit/KPKAESKeyDerivation.h>
+#import <KeePassKit/KPKArgon2KeyDerivation.h>
+#import <KeePassKit/KPKCompositeKey.h>
+#import <KeePassKit/KPKCipher.h>
+#import <KeePassKit/KPKChaCha20Cipher.h>
+#import <KeePassKit/KPKAESCipher.h>
+#import <KeePassKit/KPKTwofishCipher.h>
+
+#import <KeePassKit/KPKTree.h>
+#import <KeePassKit/KPKTree+Serializing.h>
+#import <KeePassKit/KPKTree+Synchronization.h>
+#import <KeePassKit/KPKNode.h>
+#import <KeePassKit/KPKEntry.h>
+#import <KeePassKit/KPKGroup.h>
+
+#import <KeePassKit/KPKBinary.h>
+#import <KeePassKit/KPKAttribute.h>
+#import <KeePassKit/KPKIcon.h>
+#import <KeePassKit/KPKDeletedNode.h>
+#import <KeePassKit/KPKMetaData.h>
+#import <KeePassKit/KPKTimeInfo.h>
+#import <KeePassKit/KPKAutotype.h>
+#import <KeePassKit/KPKWindowAssociation.h>
+
+#import <KeePassKit/KPKModificationRecording.h>
+#import <KeePassKit/KPKTreeDelegate.h>
+
+#import <KeePassKit/KPKErrors.h>
+
+#import <KeePassKit/NSColor+KPKAdditions.h>
+#import <KeePassKit/NSData+KPKHashedData.h>
+#import <KeePassKit/NSData+KPKKeyfile.h>
+#import <KeePassKit/NSData+KPKRandom.h>
+#import <KeePassKit/NSDictionary+KPKVariant.h>
+#import <KeePassKit/NSString+KPKCommands.h>
+#import <KeePassKit/NSString+KPKEmpty.h>
+#import <KeePassKit/NSString+KPKXmlUtilities.h>
+#import <KeePassKit/NSUUID+KPKAdditions.h>
+
+#else
+
 #import "KPKTypes.h"
 #import "KPKUTIs.h"
 #import "KPKIconTypes.h"
@@ -64,3 +119,6 @@ FOUNDATION_EXPORT const unsigned char KeePassKitVersionString[];
 #import "NSString+KPKXmlUtilities.h"
 #import "NSUUID+KPKAdditions.h"
 
+#endif
+
+#endif


### PR DESCRIPTION
This closes #14 by adding CocoaPods support to KeePassKit. Currenly `--allow-warning` is needed in order to pass the lint.