### PR TITLE
KPKCompositeKey conforms to NSCoding protocol

### DIFF
--- a/KeePassKit.xcodeproj/project.pbxproj
+++ b/KeePassKit.xcodeproj/project.pbxproj
@@ -1059,6 +1059,7 @@
 		9CED5FAD203C54DA00C9A6C5 /* KissXML.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9CED5FA4203C40DD00C9A6C5 /* KissXML.framework */; };
 		9CED5FAE203C54E700C9A6C5 /* KissXML.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9CED5FA8203C410300C9A6C5 /* KissXML.framework */; };
 		9CED5FAF203C555600C9A6C5 /* KeePassKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C5CF3181BE10B650019AA81 /* KeePassKit.framework */; };
+		AF10904F24F160F30079AA6E /* KPKTestCompositeKeyCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = AF10904E24F160F30079AA6E /* KPKTestCompositeKeyCoding.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1435,6 +1436,7 @@
 		9CED5FA6203C40F500C9A6C5 /* KissXML.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; name = KissXML.framework.dSYM; path = Carthage/Build/tvOS/KissXML.framework.dSYM; sourceTree = "<group>"; };
 		9CED5FA8203C410300C9A6C5 /* KissXML.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = KissXML.framework; path = Carthage/Build/tvOS/KissXML.framework; sourceTree = "<group>"; };
 		9CED5FAA203C411300C9A6C5 /* KissXML.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = KissXML.framework; path = Carthage/Build/watchOS/KissXML.framework; sourceTree = "<group>"; };
+		AF10904E24F160F30079AA6E /* KPKTestCompositeKeyCoding.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KPKTestCompositeKeyCoding.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1754,6 +1756,7 @@
 				4CE94DD01F69885E00EE9A5A /* KPKTestTrash.m */,
 				4C429FF120AC2BC9008F53B2 /* KPKTestUniqueBinaryNames.m */,
 				4C5CF3291BE10B650019AA81 /* Info.plist */,
+				AF10904E24F160F30079AA6E /* KPKTestCompositeKeyCoding.m */,
 			);
 			path = KeePassKitTests;
 			sourceTree = "<group>";
@@ -3511,6 +3514,7 @@
 				4C4A64271FDD601B00FD120F /* KPKTestOTP.m in Sources */,
 				4C5CF4B41BE10F090019AA81 /* KPKTestPerformance.m in Sources */,
 				4C5CF4B11BE10F090019AA81 /* KPKTestModificationDates.m in Sources */,
+				AF10904F24F160F30079AA6E /* KPKTestCompositeKeyCoding.m in Sources */,
 				4C5CF4AD1BE10F090019AA81 /* KPKTestHexColor.m in Sources */,
 				4CFAE3711D88537C007B57DB /* KPKTestKPKNumber.m in Sources */,
 				4CF7E8A61DCA4B4700BB652F /* KPKTestKeyComputation.m in Sources */,

--- a/KeePassKit/Keys/KPKCompositeKey.h
+++ b/KeePassKit/Keys/KPKCompositeKey.h
@@ -32,7 +32,7 @@
  *  It does not store key  nor password strings rather creates a composite key
  *  every time the password or keyfile is set.
  */
-@interface KPKCompositeKey : NSObject
+@interface KPKCompositeKey : NSObject <NSCoding>
 /**
  *  YES if the composite key has a password or keyfile set - that is, it's considered usable
  */

--- a/KeePassKit/Keys/KPKCompositeKey.m
+++ b/KeePassKit/Keys/KPKCompositeKey.m
@@ -38,6 +38,11 @@
 
 #import <CommonCrypto/CommonCrypto.h>
 
+NSString* const NSCodingHasPasswordKey = @"KPKCompositeKeyHasPassword";
+NSString* const NSCodingHasKeyfileKey = @"KPKCompositeKeyHasKeyfile";
+NSString* const NSCodingKdbKeyDataKey = @"KPKCompositeKeyKdbKeyData";
+NSString* const NSCodingKdbxKeyDataKey = @"KPKCompositeKeyKdbxKeyData";
+
 @interface KPKCompositeKey ()
 
 @property (copy) KPKData *kdbKeyData;
@@ -54,6 +59,16 @@
   self = [super init];
   if(self) {
     [self setPassword:password andKeyFileData:keyFileData];
+  }
+  return self;
+}
+
+- (id)initWithCoder:(NSCoder *)decoder {
+  if (self = [super init]) {
+      self.hasKeyFile = [decoder decodeBoolForKey:NSCodingHasKeyfileKey];
+      self.hasPassword = [decoder decodeBoolForKey:NSCodingHasPasswordKey];
+      self.kdbKeyData = [decoder decodeObjectForKey:NSCodingKdbKeyDataKey];
+      self.kdbxKeyData = [decoder decodeObjectForKey:NSCodingKdbxKeyDataKey];
   }
   return self;
 }
@@ -199,6 +214,15 @@
   uint8_t masterKey[kKPKKeyFileLength];
   CC_SHA256_Final(masterKey, &ctx);
   return [NSData dataWithBytes:masterKey length:kKPKKeyFileLength];
+}
+
+#pragma mark NSCoding
+
+- (void)encodeWithCoder:(NSCoder *)encoder {
+  [encoder encodeBool:self.hasKeyFile forKey:NSCodingHasKeyfileKey];
+  [encoder encodeBool:self.hasPassword forKey:NSCodingHasPasswordKey];
+  [encoder encodeObject:self.kdbKeyData forKey:NSCodingKdbKeyDataKey];
+  [encoder encodeObject:self.kdbxKeyData forKey:NSCodingKdbxKeyDataKey];
 }
 
 @end

--- a/KeePassKitTests/KPKTestCompositeKeyCoding.m
+++ b/KeePassKitTests/KPKTestCompositeKeyCoding.m
@@ -1,0 +1,43 @@
+//
+//  KPKTestCompositeKeyCoding.m
+//  KeePassKitTests macOS
+//
+//  Created by Julius Zint on 22.08.20.
+//  Copyright © 2020 HicknHack Software GmbH. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <KeePassKit/KeePassKit.h>
+
+@interface KPKTestCompositeKeyCoding : XCTestCase
+
+@end
+
+@implementation KPKTestCompositeKeyCoding
+
+- (void)setUp {
+}
+
+- (void)tearDown {
+}
+
+- (void)testCodingAndDecoding {
+    NSBundle *myBundle = [NSBundle bundleForClass:self.class];
+    NSURL *keyUrl = [myBundle URLForResource:@"Kdb1HexKey" withExtension:@"key"];
+    XCTAssertNotNil(keyUrl);
+    NSError *error;
+    NSData *keyFileData = [NSData dataWithContentsOfURL:keyUrl options:0 error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(keyFileData);
+    KPKCompositeKey *compositeKey = [[KPKCompositeKey alloc] initWithPassword:@"secret" keyFileData:keyFileData];
+    XCTAssertNotNil(compositeKey);
+    
+    NSData* archivedData = [NSKeyedArchiver archivedDataWithRootObject:compositeKey];
+    XCTAssertNotNil(archivedData);
+    KPKCompositeKey* decodedCompositeKey = [NSKeyedUnarchiver unarchiveObjectWithData:archivedData];
+    XCTAssertNotNil(decodedCompositeKey);
+    bool equals = [decodedCompositeKey testPassword:@"secret" keyFileData:keyFileData forVersion:KPKDatabaseFormatKdbx];
+    XCTAssertTrue(equals);
+}
+
+@end


### PR DESCRIPTION
This implements your suggestion from [#1089](https://github.com/MacPass/MacPass/pull/1089) and makes KPKCompositeKey conform to NSCoding protocol. With this change the TouchID unlock feature works with Keyfiles.

I forked from the 2.4.7 tag since this is the version that is currently used by MacPass and there are commits in KeePassKit that contain breaking changes.