### PR TITLE
Make MacPass compatible with the latest version of KeePassKit

### DIFF
--- a/KeePassKit/Keys/KPKCompositeKey.h
+++ b/KeePassKit/Keys/KPKCompositeKey.h
@@ -55,6 +55,8 @@
 
 - (BOOL)hasKeyOfClass:(Class)keyClass;
 
+- (void) clearKeys;
+
 /**
  Derives the final key data for the supplied parameters
  @param format The database format to use the key for (kbd or kdbx)

--- a/KeePassKit/Keys/KPKCompositeKey.m
+++ b/KeePassKit/Keys/KPKCompositeKey.m
@@ -144,7 +144,7 @@
   return YES;
 }
 
-- (void)_clearKeys {
+- (void)clearKeys {
   [self.keys removeAllObjects];
 }
 

--- a/KeePassKit/Keys/KPKCompositeKey.m
+++ b/KeePassKit/Keys/KPKCompositeKey.m
@@ -62,6 +62,15 @@
   return self;
 }
 
+- (instancetype)initWithPassword:(NSString *)password keyFileData:(NSData *)keyFileData {
+  self = [self init];
+  if(self) {
+    [self addKey:[KPKKey keyWithPassword:password]];
+    [self addKey:[KPKKey keyWithKeyFileData:keyFileData]];
+  }
+  return self;
+}
+
 - (instancetype)initWithKeys:(NSArray<KPKKey *> *)keys {
   self = [self init];
   if(self) {


### PR DESCRIPTION
MacPass needs to be able to set the keys of a `KPKCompositeKey` when the user changes the password for a database. The code for this is in `MPDocument.m`
```
    [self.compositeKey setPassword:password andKeyFileData:keyFileData];
``` 

`KPKCompositeKey` is not designed to be immutable (`addKey` is already defined). So it should be okay if we make the currently private `(void)_clearKeys` method public.